### PR TITLE
Support to generate the report to html file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 dockerrun.sh
 execrun.sh
 scan-report
+/output

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:latest
 
 COPY binary /
+COPY templates/*.tmpl /templates/
 VOLUME /data
 WORKDIR /
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,35 @@ run: |
     echo "::set-output name=go_diff_result::${result}"
 ```
 
+### 3. Export summary result 
+
+```
+- name: Export scan result to html file 
+run: | 
+    $(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 summary -report-type=snyk -path="/data/snyk.json" -output-type=table -export -export-filename="/data/go-result")
+
+- name: Upload go result html file
+uses: actions/upload-artifact@v3
+with:
+    name: html-go-result-${{github.run_id}}
+    path: go-result.html
+```
+
+### 4. Export diff result
+
+```
+- name: Export scan result to html file 
+run: | 
+    $(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 diff -report-type=snyk -path="/data/go-snyk-feature.json" -compare-to="/data/go-snyk-develop.json" -output-type=table -export -export-filename="/data/go-result")
+
+- name: Upload go result html file
+uses: actions/upload-artifact@v3
+with:
+    name: html-go-result-compare-to-develop-${{github.run_id}}
+    path: go-result.html
+
+```
+
 ## Examples in CLI
 
 ### 1. Get summary of the report
@@ -128,12 +157,23 @@ run: |
   }
 ]
 ```
-### 3. Debug with ls command
+
+### 3. Export the summary report
+
+
+`./scanreport summary -report-type=snyk -path="./fixtures/snyk-feature.json" -export -output-type=table -export-filename="snyk-summary"`
+
+
+### 4. Export the diff report
+
+`./scanreport diff -report-type=snyk -path="./fixtures/snyk-feature.json" -compare-to="./fixtures/snyk-develop.json" -output-type=table -export`
+
+### 5. Debug with ls command
 
 `docker run --rm -v $PWD/fixtures:/data oscarzhou/scan-report:latest ls -path=/data`
 
 
-### 4. Check version
+### 6. Check version
 
 `./scanreport version` 
 
@@ -142,6 +182,11 @@ run: |
 ### 1. Run with docker container
 
 `docker run --rm -v $PWD/fixtures:/data oscarzhou/scan-report:<version> summary -report-type=snyk -path="/data/snyk.json"`
+
+### 2. Export with docker container
+
+`docker run --rm -v $PWD/fixtures:/data oscarzhou/scan-report:<version> diff -report-type=snyk -path="./data/snyk-feature.json" -compare-to="./data/snyk-develop.json" -output-type=table -export -export-filename="./data/snyk-diff"`
+
 
 ## Command detail
 

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -9,6 +9,7 @@ Usage: scanreport COMMAND [OPTIONS]
 A tool for analyzing various code security reports (i.e. Snyk, Trivy). Inspired by Github Action Integration
 
 Commands:
+	export	Export the summary/diff report to html file
 	ls		List the files under the specific directory
 	version 	Show the ScanReport version information
 	summary		Return the summary of a security scan report

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -12,7 +12,7 @@ func GetVersion() {
 	version := Version{
 		Major: 0,
 		Minor: 1,
-		Patch: 6,
+		Patch: 7,
 	}
 
 	fmt.Printf("version: %d.%d.%d\n", version.Major, version.Minor, version.Patch)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -12,7 +12,7 @@ func GetVersion() {
 	version := Version{
 		Major: 0,
 		Minor: 1,
-		Patch: 7,
+		Patch: 8,
 	}
 
 	fmt.Printf("version: %d.%d.%d\n", version.Major, version.Minor, version.Patch)

--- a/main.go
+++ b/main.go
@@ -17,7 +17,8 @@ func main() {
 	flag.StringVar(&config.ReportType, "report-type", "", "snyk,trivy,gosec")
 	flag.StringVar(&config.Path, "path", "", "/path/to/current-file.json")
 	flag.StringVar(&config.CompareTo, "compare-to", "", "/path/to/previous-file.json")
-	flag.StringVar(&config.OutputType, "output-type", "", "matrix")
+	flag.StringVar(&config.OutputType, "output-type", "", "matrix,table")
+	flag.BoolVar(&config.Export, "export", false, "export the result to a html file")
 	flag.Parse()
 
 	switch command {
@@ -57,12 +58,19 @@ func main() {
 			log.Fatal(err)
 		}
 
-		result, err := s.Scan()
-		if err != nil {
-			log.Fatal(err)
-		}
+		if config.Export {
+			err = s.Export(config.OutputType)
+			if err != nil {
+				log.Fatal(err)
+			}
 
-		result.Output(config.OutputType)
+		} else {
+			result, err := s.Scan()
+			if err != nil {
+				log.Fatal(err)
+			}
+			result.Output(config.OutputType)
+		}
 
 	case "diff":
 		if config.ReportType == "" {
@@ -136,4 +144,5 @@ type GlobalConfig struct {
 	Path       string
 	OutputType string
 	CompareTo  string
+	Export     bool
 }

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ func main() {
 	flag.StringVar(&config.CompareTo, "compare-to", "", "/path/to/previous-file.json")
 	flag.StringVar(&config.OutputType, "output-type", "", "matrix,table")
 	flag.BoolVar(&config.Export, "export", false, "export the result to a html file")
+	flag.StringVar(&config.ExportFilename, "export-filename", "", "")
 	flag.Parse()
 
 	switch command {
@@ -59,7 +60,7 @@ func main() {
 		}
 
 		if config.Export {
-			err = s.Export(config.OutputType)
+			err = s.Export(config.OutputType, config.ExportFilename)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -140,9 +141,10 @@ func main() {
 }
 
 type GlobalConfig struct {
-	ReportType string
-	Path       string
-	OutputType string
-	CompareTo  string
-	Export     bool
+	ReportType     string
+	Path           string
+	OutputType     string
+	CompareTo      string
+	Export         bool
+	ExportFilename string
 }

--- a/main.go
+++ b/main.go
@@ -123,12 +123,18 @@ func main() {
 
 		}
 
-		result, err := s.Diff(base)
-		if err != nil {
-			log.Fatal(err)
+		if config.Export {
+			err = s.ExportDiff(base, config.OutputType, config.ExportFilename)
+			if err != nil {
+				log.Fatal(err)
+			}
+		} else {
+			result, err := s.Diff(base)
+			if err != nil {
+				log.Fatal(err)
+			}
+			result.Output(config.OutputType)
 		}
-
-		result.Output(config.OutputType)
 
 	case "ls":
 		cmd.List(config.Path)

--- a/prototypes/snyk.go
+++ b/prototypes/snyk.go
@@ -224,4 +224,19 @@ type ShortSnykVulnerability struct {
 	ID         string
 	ModuleName string
 	Severity   string
+	CvssScore  float64
+	Title      string
+	Version    string
+	FixedIn    []string
+}
+
+type SnykTemplate struct {
+	Name            string
+	Vulnerabilities []ShortSnykVulnerability
+	Critical        int64
+	High            int64
+	Medium          int64
+	Low             int64
+	Unknown         int64
+	Total           int64
 }

--- a/prototypes/snyk.go
+++ b/prototypes/snyk.go
@@ -232,6 +232,7 @@ type ShortSnykVulnerability struct {
 
 type SnykTemplate struct {
 	Name            string
+	Languages       []string
 	Vulnerabilities []ShortSnykVulnerability
 	Critical        int64
 	High            int64

--- a/prototypes/snyk.go
+++ b/prototypes/snyk.go
@@ -230,7 +230,7 @@ type ShortSnykVulnerability struct {
 	FixedIn    []string
 }
 
-type SnykTemplate struct {
+type SnykSummaryTemplate struct {
 	Name            string
 	Languages       []string
 	Vulnerabilities []ShortSnykVulnerability
@@ -240,4 +240,10 @@ type SnykTemplate struct {
 	Low             int64
 	Unknown         int64
 	Total           int64
+}
+
+type SnykDiffTemplate struct {
+	BaseSummary     SnykSummaryTemplate
+	FixedSummary    SnykSummaryTemplate
+	NewFoundSummary SnykSummaryTemplate
 }

--- a/prototypes/trivy.go
+++ b/prototypes/trivy.go
@@ -87,8 +87,29 @@ type Trivy struct {
 }
 
 type ShortTrivyVulnerability struct {
-	ID       string
-	Target   string
-	PkgName  string
-	Severity string
+	ID               string
+	Target           string
+	PkgName          string
+	Severity         string
+	Title            string
+	InstalledVersion string
+	FixedVersion     string
+}
+
+type ShortTrivyResult struct {
+	Target          string
+	Type            string
+	Vulnerabilities []ShortTrivyVulnerability
+	Critical        int64
+	High            int64
+	Medium          int64
+	Low             int64
+	Unknown         int64
+	Total           int64
+}
+
+type TrivyTemplate struct {
+	Name    string
+	Type    string
+	Results []ShortTrivyResult
 }

--- a/prototypes/trivy.go
+++ b/prototypes/trivy.go
@@ -89,11 +89,13 @@ type Trivy struct {
 type ShortTrivyVulnerability struct {
 	ID               string
 	Target           string
+	Type             string
 	PkgName          string
 	Severity         string
 	Title            string
 	InstalledVersion string
 	FixedVersion     string
+	CompositeID      string `json:"-"`
 }
 
 type ShortTrivyResult struct {
@@ -108,8 +110,14 @@ type ShortTrivyResult struct {
 	Total           int64
 }
 
-type TrivyTemplate struct {
+type TrivySummaryTemplate struct {
 	Name    string
 	Type    string
 	Results []ShortTrivyResult
+}
+
+type TrivyDiffTemplate struct {
+	BaseSummary     TrivySummaryTemplate
+	FixedSummary    TrivySummaryTemplate
+	NewFoundSummary TrivySummaryTemplate
 }

--- a/scan/result.go
+++ b/scan/result.go
@@ -23,6 +23,7 @@ type Result struct {
 	FixableMedium   int64
 	FixableLow      int64
 	FixableUnknown  int64
+	Languages       []string
 	Summary         string `json:"summary"`
 	Status          string `json:"status"`
 }

--- a/scan/scanner.go
+++ b/scan/scanner.go
@@ -4,4 +4,5 @@ type Scanner interface {
 	Scan() (Result, error)
 	Diff(base Scanner) (DiffResult, error)
 	Export(outputType, filename string) error
+	ExportDiff(base Scanner, outputType, filename string) error
 }

--- a/scan/scanner.go
+++ b/scan/scanner.go
@@ -3,5 +3,5 @@ package scan
 type Scanner interface {
 	Scan() (Result, error)
 	Diff(base Scanner) (DiffResult, error)
-	Export(outputType string) error
+	Export(outputType, filename string) error
 }

--- a/scan/scanner.go
+++ b/scan/scanner.go
@@ -3,4 +3,5 @@ package scan
 type Scanner interface {
 	Scan() (Result, error)
 	Diff(base Scanner) (DiffResult, error)
+	Export(outputType string) error
 }

--- a/scan/snyk.go
+++ b/scan/snyk.go
@@ -227,7 +227,7 @@ func (s *SnykScanner) ClearCache() {
 	s.ScannedVulnerabilities = make(map[string]struct{})
 }
 
-func (s *SnykScanner) Export(outputType string) error {
+func (s *SnykScanner) Export(outputType, filename string) error {
 	result, err := s.Scan()
 	if err != nil {
 		return err
@@ -249,7 +249,16 @@ func (s *SnykScanner) Export(outputType string) error {
 		Total:           result.Total,
 	}
 
-	name := fmt.Sprintf("scan-report-%s-%d.html", snykTmpl.Name, time.Now().Unix())
+	name := filename
+	if filename == "" {
+		name = fmt.Sprintf("scan-report-%s-%d.html", snykTmpl.Name, time.Now().Unix())
+		name = strings.ReplaceAll(name, "/", "-")
+	} else {
+		if !strings.HasSuffix(name, ".html") {
+			name = fmt.Sprintf("%s.html", name)
+		}
+	}
+
 	f, err := os.OpenFile("./output/"+name, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return err

--- a/scan/snyk.go
+++ b/scan/snyk.go
@@ -302,7 +302,7 @@ func (s *SnykScanner) ExportDiff(base Scanner, outputType, filename string) erro
 	compared.ClearCache()
 	baseVulns := compared.getShortVulnerabilities()
 
-	snykTmpl.BaseSummary = prototypes.SnykSummaryTemplate{
+	baseSummary := prototypes.SnykSummaryTemplate{
 		Name:            compared.Snyk.ProjectName,
 		Languages:       baseResult.Languages,
 		Vulnerabilities: baseVulns,
@@ -313,6 +313,19 @@ func (s *SnykScanner) ExportDiff(base Scanner, outputType, filename string) erro
 		Unknown:         baseResult.Unknown,
 		Total:           baseResult.Total,
 	}
+
+	if baseSummary.Name == "" || len(baseSummary.Languages) == 0 {
+		baseSummary.Name = s.Snyk.ProjectName
+		langs := make(map[string]struct{})
+		for _, vuln := range s.Snyk.Vulnerabilities {
+			langs[vuln.Language] = struct{}{}
+		}
+
+		for lang := range langs {
+			baseSummary.Languages = append(baseSummary.Languages, lang)
+		}
+	}
+	snykTmpl.BaseSummary = baseSummary
 
 	// get short vulnerabilities of current scanner
 	vulns := s.getShortVulnerabilities()

--- a/scan/snyk.go
+++ b/scan/snyk.go
@@ -259,7 +259,7 @@ func (s *SnykScanner) Export(outputType, filename string) error {
 		}
 	}
 
-	f, err := os.OpenFile("./output/"+name, os.O_RDWR|os.O_CREATE, 0644)
+	f, err := os.OpenFile("./"+name, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return err
 	}
@@ -409,7 +409,7 @@ func (s *SnykScanner) ExportDiff(base Scanner, outputType, filename string) erro
 		}
 	}
 
-	f, err := os.OpenFile("./output/"+name, os.O_RDWR|os.O_CREATE, 0644)
+	f, err := os.OpenFile("./"+name, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return err
 	}

--- a/scan/trivy.go
+++ b/scan/trivy.go
@@ -351,7 +351,7 @@ func (s *TrivyScanner) Export(outputType, filename string) error {
 		}
 	}
 
-	f, err := os.OpenFile("./output/"+name, os.O_RDWR|os.O_CREATE, 0644)
+	f, err := os.OpenFile("./"+name, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return err
 	}
@@ -512,7 +512,7 @@ func (s *TrivyScanner) ExportDiff(base Scanner, outputType, filename string) err
 		}
 	}
 
-	f, err := os.OpenFile("./output/"+name, os.O_RDWR|os.O_CREATE, 0644)
+	f, err := os.OpenFile("./"+name, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return err
 	}

--- a/scan/trivy.go
+++ b/scan/trivy.go
@@ -273,7 +273,7 @@ func (s *TrivyScanner) getSummary() string {
 	return stringBuilder
 }
 
-func (s *TrivyScanner) Export(outputType string) error {
+func (s *TrivyScanner) Export(outputType, filename string) error {
 	trivyTmpl := prototypes.TrivyTemplate{
 		Name: s.Trivy.ArtifactName,
 		Type: s.Trivy.ArtifactType,
@@ -324,8 +324,16 @@ func (s *TrivyScanner) Export(outputType string) error {
 	}
 	trivyTmpl.Results = results
 
-	name := fmt.Sprintf("scan-report-%s-%d.html", trivyTmpl.Name, time.Now().Unix())
-	name = strings.ReplaceAll(name, "/", "-")
+	name := filename
+	if filename == "" {
+		name = fmt.Sprintf("scan-report-%s-%d.html", trivyTmpl.Name, time.Now().Unix())
+		name = strings.ReplaceAll(name, "/", "-")
+	} else {
+		if !strings.HasSuffix(name, ".html") {
+			name = fmt.Sprintf("%s.html", name)
+		}
+	}
+
 	f, err := os.OpenFile("./output/"+name, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return err

--- a/scan/trivy.go
+++ b/scan/trivy.go
@@ -267,3 +267,7 @@ func (s *TrivyScanner) getSummary() string {
 
 	return stringBuilder
 }
+
+func (s *TrivyScanner) Export(outputType string) error {
+	return nil
+}

--- a/templates/html-table.go.tmpl
+++ b/templates/html-table.go.tmpl
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+
+<html>
+
+<head>
+	<style>
+    	table: {border: 1px solid black}
+    </style>
+</head>
+<body>
+
+
+Project: {{ .Name }}
+
+<br/>
+
+Total: {{ .Total }} (UNKNOWN: {{ .Unknown }}, LOW: {{ .Low }}, MEDIUM: {{ .Medium }}, HIGH: {{ .High }}, CRITICAL: {{ .Critical }})
+
+
+<table>
+	<tr>
+      <th>MODULE NAME</th>
+      <th>VULNERABILITY ID</th>
+      <th>SEVERITY</th>
+      <th>INSTALLED VERSION</th>
+      <th>FXIED VERSION</th>
+      <th>TITLE</th>
+    </tr>
+    {{ range .Vulnerabilities }}
+	<tr>
+    	<td>{{ .ModuleName }}</td>
+        <td>{{ .ID }}</td>
+        <td>{{ .Severity }}</td>
+        <td>{{ .Version }}</td>
+        <td>{{ .FixedIn }}</td>
+        <td>{{ .Title }}</td>
+    </tr>
+    {{ end }}
+</table>
+
+</body>
+</html>

--- a/templates/snyk-diff-html-table.go.tmpl
+++ b/templates/snyk-diff-html-table.go.tmpl
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+
+<html>
+
+<head>
+    <title>{{ .BaseSummary.Name }} | {{ join .BaseSummary.Languages ", " }}</title>
+	<style>
+        .summary {
+        font-family: Arial, Helvetica, sans-serif;
+        border-collapse: collapse;
+        width: 100%;
+        }
+
+        .summary td, .summary th {
+        border: 1px solid #ddd;
+        padding: 8px;
+        }
+
+        .summary tr:nth-child(even){background-color: #f2f2f2;}
+
+        .summary tr:hover {background-color: #ddd;}
+
+        .summary th {
+        padding-top: 12px;
+        padding-bottom: 12px;
+        text-align: left;
+        background-color: #04AA6D;
+        color: white;
+        }
+    </style>
+</head>
+<body>
+
+<h2> Project: {{ .BaseSummary.Name }}, Language: {{ join .BaseSummary.Languages ", " }}  </h2>
+
+<br/>
+
+Compare to the develop branch 
+
+<h3> New found vulnerabilities in the current branch</h3>
+
+{{with .NewFoundSummary}}
+
+Total: {{ .Total }} (UNKNOWN: {{ .Unknown }}, LOW: {{ .Low }}, MEDIUM: {{ .Medium }}, HIGH: {{ .High }}, CRITICAL: {{ .Critical }})
+
+<br/>
+
+<table class="summary">
+	<tr>
+      <th>MODULE NAME</th>
+      <th>VULNERABILITY ID</th>
+      <th>SEVERITY</th>
+      <th>INSTALLED VERSION</th>
+      <th>FXIED VERSION</th>
+      <th>TITLE</th>
+    </tr>
+    {{ range .Vulnerabilities }}
+	<tr>
+    	<td>{{ .ModuleName }}</td>
+        <td>{{ .ID }}</td>
+        <td>{{ .Severity }}</td>
+        <td>{{ .Version }}</td>
+        <td>{{ join .FixedIn ", " }}</td>
+        <td>{{ .Title }}</td>
+    </tr>
+    {{ end }}
+</table>
+
+{{ end }}
+
+<br/>
+
+<h3> Fixed vulnerabilities in the current branch</h3>
+
+{{with .FixedSummary}}
+
+Total: {{ .Total }} (UNKNOWN: {{ .Unknown }}, LOW: {{ .Low }}, MEDIUM: {{ .Medium }}, HIGH: {{ .High }}, CRITICAL: {{ .Critical }})
+
+<br/>
+
+<table class="summary">
+	<tr>
+      <th>MODULE NAME</th>
+      <th>VULNERABILITY ID</th>
+      <th>SEVERITY</th>
+      <th>INSTALLED VERSION</th>
+      <th>FXIED VERSION</th>
+      <th>TITLE</th>
+    </tr>
+    {{ range .Vulnerabilities }}
+	<tr>
+    	<td>{{ .ModuleName }}</td>
+        <td>{{ .ID }}</td>
+        <td>{{ .Severity }}</td>
+        <td>{{ .Version }}</td>
+        <td>{{ join .FixedIn ", " }}</td>
+        <td>{{ .Title }}</td>
+    </tr>
+    {{ end }}
+</table>
+
+{{ end }}
+
+<br/>
+
+<h3> Develop branch </h3>
+
+{{with .BaseSummary}}
+
+Total: {{ .Total }} (UNKNOWN: {{ .Unknown }}, LOW: {{ .Low }}, MEDIUM: {{ .Medium }}, HIGH: {{ .High }}, CRITICAL: {{ .Critical }})
+
+<br/>
+
+<table class="summary">
+	<tr>
+      <th>MODULE NAME</th>
+      <th>VULNERABILITY ID</th>
+      <th>SEVERITY</th>
+      <th>INSTALLED VERSION</th>
+      <th>FXIED VERSION</th>
+      <th>TITLE</th>
+    </tr>
+    {{ range .Vulnerabilities }}
+	<tr>
+    	<td>{{ .ModuleName }}</td>
+        <td>{{ .ID }}</td>
+        <td>{{ .Severity }}</td>
+        <td>{{ .Version }}</td>
+        <td>{{ join .FixedIn ", " }}</td>
+        <td>{{ .Title }}</td>
+    </tr>
+    {{ end }}
+</table>
+
+{{ end }}
+
+</body>
+</html>

--- a/templates/snyk-sum-html-table.go.tmpl
+++ b/templates/snyk-sum-html-table.go.tmpl
@@ -3,8 +3,30 @@
 <html>
 
 <head>
+    <title>{{ .Name }} | {{ join .Languages ", " }}</title>
 	<style>
-    	table: {border: 1px solid black}
+        .summary {
+        font-family: Arial, Helvetica, sans-serif;
+        border-collapse: collapse;
+        width: 100%;
+        }
+
+        .summary td, .summary th {
+        border: 1px solid #ddd;
+        padding: 8px;
+        }
+
+        .summary tr:nth-child(even){background-color: #f2f2f2;}
+
+        .summary tr:hover {background-color: #ddd;}
+
+        .summary th {
+        padding-top: 12px;
+        padding-bottom: 12px;
+        text-align: left;
+        background-color: #04AA6D;
+        color: white;
+        }
     </style>
 </head>
 <body>
@@ -14,10 +36,15 @@ Project: {{ .Name }}
 
 <br/>
 
+Language: {{ join .Languages ", " }}
+
+<br/>
+
 Total: {{ .Total }} (UNKNOWN: {{ .Unknown }}, LOW: {{ .Low }}, MEDIUM: {{ .Medium }}, HIGH: {{ .High }}, CRITICAL: {{ .Critical }})
 
+<br/>
 
-<table>
+<table class="summary">
 	<tr>
       <th>MODULE NAME</th>
       <th>VULNERABILITY ID</th>

--- a/templates/template.go
+++ b/templates/template.go
@@ -1,0 +1,8 @@
+package templates
+
+const (
+	SNYK_SUMMARY_HTML_TABLE  string = "snyk-sum-html-table.go.tmpl"
+	SNYK_DIFF_HTML_TABLE     string = "snyk-diff-html-table.go.tmpl"
+	TRIVY_SUMMARY_HTML_TABLE string = "trivy-sum-html-table.go.tmpl"
+	TRIVY_DIFF_HTML_TABLE    string = "trivy-diff-html-table.go.tmpl"
+)

--- a/templates/trivy-diff-html-table.go.tmpl
+++ b/templates/trivy-diff-html-table.go.tmpl
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+
+<html>
+
+<head>
+    <title>{{ .BaseSummary.Name }} | {{ .BaseSummary.Type }}</title>
+	<style>
+        .summary {
+        font-family: Arial, Helvetica, sans-serif;
+        border-collapse: collapse;
+        width: 100%;
+        }
+
+        .summary td, .summary th {
+        border: 1px solid #ddd;
+        padding: 8px;
+        }
+
+        .summary tr:nth-child(even){background-color: #f2f2f2;}
+
+        .summary tr:hover {background-color: #ddd;}
+
+        .summary th {
+        padding-top: 12px;
+        padding-bottom: 12px;
+        text-align: left;
+        background-color: #04AA6D;
+        color: white;
+        }
+    </style>
+</head>
+<body>
+
+
+<h2> Project: {{ .BaseSummary.Name }}, Type: {{ .BaseSummary.Type }} </h2>
+
+<br/>
+
+Compare to the develop branch 
+
+<h3> New found vulnerabilities in the current branch</h3>
+
+{{with .NewFoundSummary}}
+
+{{ range .Results }}
+
+{{ .Target }} ({{ .Type }})
+<br/>
+Total: {{ .Total }} (UNKNOWN: {{ .Unknown }}, LOW: {{ .Low }}, MEDIUM: {{ .Medium }}, HIGH: {{ .High }}, CRITICAL: {{ .Critical }})
+
+<br/>
+
+<table class="summary">
+	<tr>
+      <th>MODULE NAME</th>
+      <th>VULNERABILITY ID</th>
+      <th>SEVERITY</th>
+      <th>INSTALLED VERSION</th>
+      <th>FXIED VERSION</th>
+      <th>TITLE</th>
+    </tr>
+    {{ range .Vulnerabilities }}
+	<tr>
+    	<td>{{ .PkgName }}</td>
+        <td>{{ .ID }}</td>
+        <td>{{ .Severity }}</td>
+        <td>{{ .InstalledVersion }}</td>
+        <td>{{ .FixedVersion }}</td>
+        <td>{{ .Title }}</td>
+    </tr>
+    {{ end }}
+</table>
+
+<br/>
+<br/>
+{{ end }}
+
+{{ end }}
+
+<br />
+
+<h3> Fixed vulnerabilities in the current branch</h3>
+
+{{with .FixedSummary}}
+
+{{ range .Results }}
+
+{{ .Target }} ({{ .Type }})
+<br/>
+Total: {{ .Total }} (UNKNOWN: {{ .Unknown }}, LOW: {{ .Low }}, MEDIUM: {{ .Medium }}, HIGH: {{ .High }}, CRITICAL: {{ .Critical }})
+
+<br/>
+
+<table class="summary">
+	<tr>
+      <th>MODULE NAME</th>
+      <th>VULNERABILITY ID</th>
+      <th>SEVERITY</th>
+      <th>INSTALLED VERSION</th>
+      <th>FXIED VERSION</th>
+      <th>TITLE</th>
+    </tr>
+    {{ range .Vulnerabilities }}
+	<tr>
+    	<td>{{ .PkgName }}</td>
+        <td>{{ .ID }}</td>
+        <td>{{ .Severity }}</td>
+        <td>{{ .InstalledVersion }}</td>
+        <td>{{ .FixedVersion }}</td>
+        <td>{{ .Title }}</td>
+    </tr>
+    {{ end }}
+</table>
+
+<br/>
+<br/>
+{{ end }}
+
+{{ end }}
+
+<br />
+
+<h3> Develop branch </h3>
+
+{{with .BaseSummary}}
+
+{{ range .Results }}
+
+{{ .Target }} ({{ .Type }})
+<br/>
+Total: {{ .Total }} (UNKNOWN: {{ .Unknown }}, LOW: {{ .Low }}, MEDIUM: {{ .Medium }}, HIGH: {{ .High }}, CRITICAL: {{ .Critical }})
+
+<br/>
+
+<table class="summary">
+	<tr>
+      <th>MODULE NAME</th>
+      <th>VULNERABILITY ID</th>
+      <th>SEVERITY</th>
+      <th>INSTALLED VERSION</th>
+      <th>FXIED VERSION</th>
+      <th>TITLE</th>
+    </tr>
+    {{ range .Vulnerabilities }}
+	<tr>
+    	<td>{{ .PkgName }}</td>
+        <td>{{ .ID }}</td>
+        <td>{{ .Severity }}</td>
+        <td>{{ .InstalledVersion }}</td>
+        <td>{{ .FixedVersion }}</td>
+        <td>{{ .Title }}</td>
+    </tr>
+    {{ end }}
+</table>
+
+<br/>
+<br/>
+{{ end }}
+
+{{ end }}
+
+<br />
+
+
+</body>
+</html>

--- a/templates/trivy-sum-html-table.go.tmpl
+++ b/templates/trivy-sum-html-table.go.tmpl
@@ -39,6 +39,7 @@
 {{ range .Results }}
 
 {{ .Target }} ({{ .Type }})
+<br/>
 Total: {{ .Total }} (UNKNOWN: {{ .Unknown }}, LOW: {{ .Low }}, MEDIUM: {{ .Medium }}, HIGH: {{ .High }}, CRITICAL: {{ .Critical }})
 
 <br/>

--- a/templates/trivy-sum-html-table.go.tmpl
+++ b/templates/trivy-sum-html-table.go.tmpl
@@ -3,7 +3,7 @@
 <html>
 
 <head>
-    <title>{{ .Name }} | {{ join .Languages ", " }}</title>
+    <title>{{ .Name }} | {{ .Type }}</title>
 	<style>
         .summary {
         font-family: Arial, Helvetica, sans-serif;
@@ -32,10 +32,13 @@
 <body>
 
 
-<h2> Project: {{ .Name }}, Language: {{ join .Languages ", " }}  </h2>
+<h2> Project: {{ .Name }}, Type: {{ .Type }} </h2>
 
 <br/>
 
+{{ range .Results }}
+
+{{ .Target }} ({{ .Type }})
 Total: {{ .Total }} (UNKNOWN: {{ .Unknown }}, LOW: {{ .Low }}, MEDIUM: {{ .Medium }}, HIGH: {{ .High }}, CRITICAL: {{ .Critical }})
 
 <br/>
@@ -51,15 +54,19 @@ Total: {{ .Total }} (UNKNOWN: {{ .Unknown }}, LOW: {{ .Low }}, MEDIUM: {{ .Mediu
     </tr>
     {{ range .Vulnerabilities }}
 	<tr>
-    	<td>{{ .ModuleName }}</td>
+    	<td>{{ .PkgName }}</td>
         <td>{{ .ID }}</td>
         <td>{{ .Severity }}</td>
-        <td>{{ .Version }}</td>
-        <td>{{ join .FixedIn ", " }}</td>
+        <td>{{ .InstalledVersion }}</td>
+        <td>{{ .FixedVersion }}</td>
         <td>{{ .Title }}</td>
     </tr>
     {{ end }}
 </table>
+
+<br/>
+<br/>
+{{ end }}
 
 </body>
 </html>


### PR DESCRIPTION
Fixes: #1 


This PR should support to generate both `summary` and `diff` report to HTML file and for all report types. (Currently `snyk`, `trivy`)

- [x] generate snyk summary report to HTML file
- [x]  generate snyk diff report to HTML file
- [x]  generate trivy summary report to HTML file
- [x]  generate trivy diff report to HTML file